### PR TITLE
Fixed default help command

### DIFF
--- a/src/AxonClient.js
+++ b/src/AxonClient.js
@@ -722,7 +722,7 @@ class AxonClient extends EventEmitter {
         let commandList = '';
         if (guildConfig) {
             for (const module of this.modules.values()) {
-                const commands = module.commands.filter(c => c.canExecute(msg.channel, msg.member, guildConfig));
+                const commands = module.commands.filter(c => c.canExecute(msg, guildConfig));
                 if (commands.length > 0) {
                     commandList += `**${module.label}**\n${commands.map(c => `\`${prefix}${c.label}\` - ${c.infos.description}`).join('\n')}\n`;
                 }


### PR DESCRIPTION
Fixed help command, there was the issue of using `command.canExecute` incorrectly.