### PR TITLE
Fixed owner prefix not working

### DIFF
--- a/src/Structures/MessageHandler.js
+++ b/src/Structures/MessageHandler.js
@@ -137,7 +137,6 @@ class MessageHandler {
         /** Resolve command (and subcommand if needed) - exec command if the command was resolved */
         const command = this.axon.resolveCommand(label, args); // doesn't pass guildConf so it doesn't check for server disabled
         if (!command) { // command doesn't exist or not globally enabled
-            console.log('Command not found!')
             return Promise.resolve();
         }
         msg.command = command;

--- a/src/Structures/MessageHandler.js
+++ b/src/Structures/MessageHandler.js
@@ -73,10 +73,10 @@ class MessageHandler {
         }
 
         /** Admin override */
-        if (msg.content.startsWith(this.axon.params.ownerPrefix) && this.axon.AxonUtils.isBotOwner(msg.author.id) ) { // Owner override everything
+        if (msg.content.startsWith(this.axon.params.ownerPrefix) && !!this.axon.AxonUtils.isBotOwner(msg.author.id) ) { // Owner override everything
             this._onAdmin(msg, guildConf, true);
             return;
-        } if (msg.content.startsWith(this.axon.params.adminPrefix) && this.axon.AxonUtils.isBotAdmin(msg.author.id) ) { // ADMIN override everything except owner
+        } if (msg.content.startsWith(this.axon.params.adminPrefix) && !!this.axon.AxonUtils.isBotAdmin(msg.author.id) ) { // ADMIN override everything except owner
             this._onAdmin(msg, guildConf, false);
             return;
         }
@@ -124,7 +124,7 @@ class MessageHandler {
      * @memberof AxonClient
      */
     _onAdmin(msg, guildConf, isOwner) {
-        msg.prefix = this.axon.params.adminPrefix;
+        msg.prefix = !isOwner ? this.axon.params.adminPrefix : this.axon.params.ownerPrefix;
 
         const args = msg.content.replace(/<@!/g, '<@').substring(msg.prefix.length).split(' ');
         const label = args.shift().toLowerCase();
@@ -137,6 +137,7 @@ class MessageHandler {
         /** Resolve command (and subcommand if needed) - exec command if the command was resolved */
         const command = this.axon.resolveCommand(label, args); // doesn't pass guildConf so it doesn't check for server disabled
         if (!command) { // command doesn't exist or not globally enabled
+            console.log('Command not found!')
             return Promise.resolve();
         }
         msg.command = command;


### PR DESCRIPTION
Owner prefix was not working due to how checking if someone was owner when a message was ran, and it also broke when the owner prefix and admin prefix were of different lengths.

# The first check

Original:
```if (msg.content.startsWith(this.axon.params.ownerPrefix) /* This part was ok */ && this.axon.AxonUtils.isBotOwner(msg.author.id) /* This was causing it */)```

Modified (working):
 ```if (msg.content.startsWith(this.axon.params.ownerPrefix) && /* This part fixed it */ !!this.axon.AxonUtils.isBotOwner(msg.author.id))```

I checked if it was the owner properly, by making it check Boolean.

# The prefix length

Original:
 ```msg.prefix = this.axon.params.adminPrefix;

const args = msg.content.replace(/<@!/g, '<@').substring(msg.prefix.length /* This is not good if the owner prefix has a different length than the admin prefix */).split(' ');```

Modified:
```msg.prefix = !isOwner /* If this is just a admin */ ? this.axon.params.adminPrefix : /* If it is a owner */ this.axon.params.ownerPrefix;```

This basically ensures that it is splitting the right length for the prefix, otherwise the command will not resolve properly.

- Null