### PR TITLE
Fix updating blacklistedGuilds (MongoService)

### DIFF
--- a/src/Database/MongoService.js
+++ b/src/Database/MongoService.js
@@ -143,7 +143,7 @@ class MongoService extends DBService {
         },
         {
             $set: {
-                bannedUsers: blacklistedGuilds,
+                bannedGuilds: blacklistedGuilds,
             },
         },
         {


### PR DESCRIPTION
Updating blacklisted guilds had a typo and set the users to the guilds array instead of setting the banned users to the blacklisted guilds array given. Simple fix but could be devastating to some. I found this in the MongoService.