### PR TITLE
Updated Enums, added perms calculator (Utility).

### DIFF
--- a/src/Database/MongoService.js
+++ b/src/Database/MongoService.js
@@ -143,7 +143,7 @@ class MongoService extends DBService {
         },
         {
             $set: {
-                bannedUsers: blacklistedGuilds,
+                bannedGuilds: blacklistedGuilds,
             },
         },
         {

--- a/src/Errors/AxonError.js
+++ b/src/Errors/AxonError.js
@@ -10,10 +10,10 @@ class AxonError extends Error {
     /**
      * Creates an instance of AxonError.
      *
-     * @param {String} message - custom message
-     * @param {Object<Module>} module (optional)
-     * @param {Object<Command>} command (optional)
-     * @param {Object} err - error object (optional)
+     * @param {String} message - custom error message
+     * @param {Object<Module>} [module] Module in which the error originated from
+     * @param {Object<Command>} [command] Command from which the error originated from
+     * @param {Object} [err] - error object
      * @memberof AxonError
      */
     constructor(message, module, command, err) {

--- a/src/Utility/Enums.js
+++ b/src/Utility/Enums.js
@@ -74,10 +74,48 @@ const typeError = {
     unexpected: 'Unexpected error',
 };
 
+const permissionNumbers = {
+    createInstantInvite: 1,
+    kickMembers: 2,
+    banMembers: 4,
+    administrator: 8,
+    manageChannels: 16,
+    manageGuild: 32,
+    addReactions: 64,
+    viewAuditLogs: 128,
+    voicePrioritySpeaker: 256,
+    readMessages: 1024,
+    sendMessages: 2048,
+    sendTTSMessages: 4096,
+    manageMessages: 8192,
+    embedLinks: 16384,
+    attachFiles: 32768,
+    readMessageHistory: 65536,
+    mentionEveryone: 131072,
+    externalEmojis: 262144,
+    voiceConnect: 1048576,
+    voiceSpeak: 2097152,
+    voiceMuteMembers: 4194304,
+    voiceDeafenMembers: 8388608,
+    voiceMoveMembers: 16777216,
+    voiceUseVAD: 33554432,
+    changeNickname: 67108864,
+    manageNicknames: 134217728,
+    manageRoles: 268435456,
+    manageWebhooks: 536870912,
+    manageEmojis: 1073741824,
+    all: 2146958847,
+    allGuild: 2080374975,
+    allText: 805829713,
+    allVoice: 871366929,
+};
+
+
 export default {
     permissions,
     permissionsNames,
     adminPerms,
     typeWH,
     typeError,
+    nums,
 };

--- a/src/Utility/Enums.js
+++ b/src/Utility/Enums.js
@@ -117,5 +117,5 @@ export default {
     adminPerms,
     typeWH,
     typeError,
-    nums,
+    permissionNumbers,
 };

--- a/src/Utility/Utils.js
+++ b/src/Utility/Utils.js
@@ -1,5 +1,7 @@
 import fs from 'fs';
 import util from 'util';
+import AxonError from '../Errors/AxonError';
+import { permissionNumbers } from './Enums';
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
 
@@ -152,11 +154,11 @@ class Utils {
         if (!role1) {
             return false;
         }
-        
+
         if (role1 && !role2) {
             return true;
         }
-        
+
         return role1.position > role2.position;
     }
 
@@ -228,6 +230,36 @@ class Utils {
             }
         }
         return missing;
+    }
+
+    /**
+     * Calculate permissions using a object of perms
+     *
+     * @param {Object} data The permissions to calculate for
+     *
+     *  @returns {Object} Object containing the perms denied & allowed
+     */
+    calculatePerms(data) {
+        let allow = 0;
+        let deny = 0;
+        for (const key of Object.keys(data) ) {
+            if (!permissionNumbers[key] ) throw new AxonError(`Key ${key} not found!`, 'Enums');
+            if (data[key] === true) {
+                allow = Math.round(allow + permissionNumbers[key] );
+            } else if (data[key] === false) {
+                deny = Math.round(deny + permissionNumbers[key] );
+            }
+            if (key === 'all') {
+                if (data[key] === true) {
+                    allow = permissionNumbers[key];
+                    break;
+                } else if (data[key] === false) {
+                    deny = permissionNumbers[key];
+                    break;
+                }
+            }
+        }
+        return { allow, deny };
     }
 
     //


### PR DESCRIPTION
Added a Utility permission calculator to turn object representation to number representation.
Example: ```js
const Utils = this.axon.Utils;
const objPerms = { readMessages: true, sendMessages: false };
const perms = Utils.calculatePermissions(objPerms);
console.log(perms); // Output: { allow: 1024, deny: 2048 }```