### PR TITLE
[Important] Fix imports in src/Utility/Utils.js

### DIFF
--- a/src/Utility/Utils.js
+++ b/src/Utility/Utils.js
@@ -1,9 +1,11 @@
 import fs from 'fs';
 import util from 'util';
 import AxonError from '../Errors/AxonError';
-import { permissionNumbers } from './Enums';
+import Enums from './Enums';
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
+
+const { permissionNumbers } = Enums;
 
 const USER_MENTION = /<@!?([0-9]+)>$/;
 const ROLE_MENTION = /<@&([0-9]+)>$/;


### PR DESCRIPTION
IMPORTANT

So i did not realize you could not import permissionNumbers directly from the Enums file. I imported the Enums then destructed permissionNumbers from Enums.

This should have fixed the error that occured when trying to run with AxonCore dev branch.