### PR TITLE
refactor: Subcommands initialisation

### DIFF
--- a/examples/djs/src/modules/Core/commands/Ping.js
+++ b/examples/djs/src/modules/Core/commands/Ping.js
@@ -14,7 +14,6 @@ class Ping extends Command {
         ];
 
         this.hasSubcmd = true;
-        this.subcmds = [Pong];
 
         this.info = {
             owners: ['KhaaZ'],
@@ -28,6 +27,10 @@ class Ping extends Command {
             argsMin: 0,
             guildOnly: false,
         } );
+    }
+
+    init() {
+        return [Pong];
     }
 
     async execute( { msg } ) {

--- a/examples/djs/src/modules/Core/commands/Ping_Pong.js
+++ b/examples/djs/src/modules/Core/commands/Ping_Pong.js
@@ -9,7 +9,6 @@ class Pong extends Command {
         this.label = 'pong';
         this.aliases = ['pong'];
 
-        this.isSubcmd = true;
         this.hasSubcmd = true;
         this.subcmds = [Pang];
 

--- a/examples/djs/src/modules/Core/commands/Ping_Pong_Pang.js
+++ b/examples/djs/src/modules/Core/commands/Ping_Pong_Pang.js
@@ -9,9 +9,7 @@ class Pang extends Command {
         this.label = 'pang';
         this.aliases = ['pang'];
 
-        this.isSubcmd = true;
         this.hasSubcmd = true;
-        this.subcmds = [Pung];
 
         this.info = {
             owners: ['KhaaZ'],
@@ -32,6 +30,10 @@ class Pang extends Command {
         this.permissions = new CommandPermissions(this, {
             serverMod: true,
         } );
+    }
+
+    init() {
+        return [Pung];
     }
 
     async execute( { msg } ) {

--- a/examples/djs/src/modules/Core/commands/Ping_Pong_Pang_Pung.js
+++ b/examples/djs/src/modules/Core/commands/Ping_Pong_Pang_Pung.js
@@ -7,7 +7,6 @@ class Pung extends Command {
         this.label = 'pung';
         this.aliases = ['pung'];
 
-        this.isSubcmd = true;
         this.hasSubcmd = false;
 
         this.info = {

--- a/examples/eris/src/modules/Core/commands/Ping.js
+++ b/examples/eris/src/modules/Core/commands/Ping.js
@@ -14,7 +14,6 @@ class Ping extends Command {
         ];
 
         this.hasSubcmd = true;
-        this.subcmds = [Pong];
 
         this.info = {
             owners: ['KhaaZ'],
@@ -28,6 +27,10 @@ class Ping extends Command {
             argsMin: 0,
             guildOnly: false,
         } );
+    }
+
+    init() {
+        return [Pong];
     }
 
     async execute( { msg } ) {

--- a/examples/eris/src/modules/Core/commands/Ping_Pong.js
+++ b/examples/eris/src/modules/Core/commands/Ping_Pong.js
@@ -9,9 +9,7 @@ class Pong extends Command {
         this.label = 'pong';
         this.aliases = ['pong'];
 
-        this.isSubcmd = true;
         this.hasSubcmd = true;
-        this.subcmds = [Pang];
 
         this.info = {
             owners: ['KhaaZ'],
@@ -37,6 +35,10 @@ class Pong extends Command {
                 bypass: [...this.axon.staff.owners, ...this.axon.staff.admins],
             },
         } );
+    }
+
+    init() {
+        return [Pang];
     }
 
     async execute( { msg } ) {

--- a/examples/eris/src/modules/Core/commands/Ping_Pong_Pang.js
+++ b/examples/eris/src/modules/Core/commands/Ping_Pong_Pang.js
@@ -9,9 +9,7 @@ class Pang extends Command {
         this.label = 'pang';
         this.aliases = ['pang'];
 
-        this.isSubcmd = true;
         this.hasSubcmd = true;
-        this.subcmds = [Pung];
 
         this.info = {
             owners: ['KhaaZ'],
@@ -32,6 +30,10 @@ class Pang extends Command {
         this.permissions = new CommandPermissions(this, {
             serverMod: true,
         } );
+    }
+
+    init() {
+        return [Pung];
     }
 
     async execute( { msg } ) {

--- a/examples/eris/src/modules/Core/commands/Ping_Pong_Pang_Pung.js
+++ b/examples/eris/src/modules/Core/commands/Ping_Pong_Pang_Pung.js
@@ -7,7 +7,6 @@ class Pung extends Command {
         this.label = 'pung';
         this.aliases = ['pung'];
 
-        this.isSubcmd = true;
         this.hasSubcmd = false;
 
         this.info = {

--- a/src/Core/Command/Command.js
+++ b/src/Core/Command/Command.js
@@ -187,7 +187,7 @@ class Command extends Base {
     /**
      * Returns all the subcommands for a command
      *
-     * @returns {Array<Command>} An Array of Commands class (non instantiated)
+     * @returns {Array<new (...args[]: any) => Command>} An Array of Commands class (non instantiated)
      */
     init() {
         // return this.subcmds for backward compatibility

--- a/src/Core/Command/Command.js
+++ b/src/Core/Command/Command.js
@@ -6,6 +6,8 @@ import CommandCooldown from './CommandCooldown';
 import CommandContext from './CommandContext';
 import CommandResponse from './CommandResponse';
 
+import CommandRegistry from '../Stores/CommandRegistry';
+
 import AxonError from '../../Errors/AxonError';
 import AxonCommandError from '../../Errors/AxonCommandError';
 
@@ -39,7 +41,7 @@ import { COMMAND_EXECUTION_STATE } from '../../Utility/Constants/AxonEnums';
  *
  * @prop {Command} [parentCommand=null] - Reference to the parent command
  * @prop {Boolean} [hasSubcmd=false] - Whether the command HAS subcommands
- * @prop {CommandRegistry} [subCommands=null] - Collection of subcommands
+ * @prop {CommandRegistry} [subCommands=null] - Registry of subcommands
  *
  * @prop {Object} info - Default info about the command
  * @prop {Array<String>} [info.owners] - Command authors
@@ -190,6 +192,19 @@ class Command extends Base {
     init() {
         // return this.subcmds for backward compatibility
         return this.subcmds || [];
+    }
+
+    /**
+     * @returns {Boolean}
+     */
+    _init() {
+        if (!this.hasSubcmd) {
+            return false;
+        }
+        const commands = this.init();
+        this.subCommands = new CommandRegistry(this.axon);
+
+        return this.module.commandLoader.loadSubCommands(this, commands);
     }
 
     // **** MAIN **** //

--- a/src/Core/Command/Command.js
+++ b/src/Core/Command/Command.js
@@ -188,7 +188,7 @@ class Command extends Base {
      * @returns {Array<Command>} An Array of Commands class (non instantiated)
      */
     init() {
-        // return this.suncmds for backward compatibility
+        // return this.subcmds for backward compatibility
         return this.subcmds || [];
     }
 

--- a/src/Core/Command/Command.js
+++ b/src/Core/Command/Command.js
@@ -37,10 +37,8 @@ import { COMMAND_EXECUTION_STATE } from '../../Utility/Constants/AxonEnums';
  * @prop {Boolean} [enabled=module.enabled] - Whether the command is enabled
  * @prop {Boolean} [serverBypass=module.serverBypass] - Whether the command can be disabled
  *
- * @prop {Boolean} [isSubcmd=false] - Whether the command IS a subcommand
- * @prop {Command} [parentCommand=null] - Reference to the parent command (if isSubcmd = true)
+ * @prop {Command} [parentCommand=null] - Reference to the parent command
  * @prop {Boolean} [hasSubcmd=false] - Whether the command HAS subcommands
- * @prop {Array<Object>} subcmds - Array of subcommand objects (deleted after init)
  * @prop {CommandRegistry} [subCommands=null] - Collection of subcommands
  *
  * @prop {Object} info - Default info about the command
@@ -63,7 +61,6 @@ class Command extends Base {
      * @param {Object} [data={}] - All command parameters
      * @param {String} [data.label] - The command label
      * @param {Array<String>} [data.aliases] - The command aliases
-     * @param {Boolean} [data.isSubcmd] - Whether the command IS a subcommand
      * @param {Boolean} [data.hasSubcmd] - Whether the command HAS subcommands
      * @param {Boolean} [data.enabled] - Whether the command is enabled
      * @param {Boolean} [data.serverBypass] - Whether the command can be server disabled
@@ -91,11 +88,8 @@ class Command extends Base {
         this.enabled = data.enabled !== undefined ? data.enabled : module.enabled; // Default to module state
 
         /* Subcommands */
-        this.isSubcmd = data.isSubcmd || false;
         this.parentCommand = null; // Reference to the parent command - affected at instantiation
         this.hasSubcmd = data.hasSubcmd || false;
-        // temp var used to init subcommands
-        this.subcmds = data.subcmds || []; // Array of imported commands - deleted after init
 
         /**
          * @type {CommandRegistry}
@@ -186,6 +180,16 @@ class Command extends Base {
             return this.label;
         }
         return `${this.parentCommand.fullLabel} ${this.label}`;
+    }
+
+    /**
+     * Returns all the subcommands for a command
+     *
+     * @returns {Array<Command>} An Array of Commands class (non instantiated)
+     */
+    init() {
+        // return this.suncmds for backward compatibility
+        return this.subcmds || [];
     }
 
     // **** MAIN **** //

--- a/src/Core/Command/Command.js
+++ b/src/Core/Command/Command.js
@@ -188,6 +188,7 @@ class Command extends Base {
      * Returns all the subcommands for a command
      *
      * @returns {Array<new (...args[]: any) => Command>} An Array of Commands class (non instantiated)
+     * @memberof Command
      */
     init() {
         // return this.subcmds for backward compatibility
@@ -196,6 +197,7 @@ class Command extends Base {
 
     /**
      * @returns {Boolean}
+     * @memberof Command
      */
     _init() {
         if (!this.hasSubcmd) {

--- a/src/Core/Command/Command.js
+++ b/src/Core/Command/Command.js
@@ -66,7 +66,6 @@ class Command extends Base {
      * @param {Boolean} [data.hasSubcmd] - Whether the command HAS subcommands
      * @param {Boolean} [data.enabled] - Whether the command is enabled
      * @param {Boolean} [data.serverBypass] - Whether the command can be server disabled
-     * @param {Array<new (...args[]: any) => Command>} [data.subcmds] - List of subcommands class to be added in the Command
      * @param {Object} [data.info]
      * @param {Array<String>} [data.info.owners] - Who created the command
      * @param {String} [data.info.description] - The command description

--- a/src/Core/Loaders/CommandLoader.js
+++ b/src/Core/Loaders/CommandLoader.js
@@ -114,18 +114,15 @@ class CommandLoader extends ALoader {
      * @memberof Command
      */
     loadSubCommands(parentCommand) {
+        const subcmds = parentCommand.init();
         /* No subCommands */
-        if (!parentCommand.subCommands || !parentCommand.subcmds.length) {
+        if (!parentCommand.subCommands || !subcmds.length) {
             this.logger.error(`[Module(${this._module.label})] Command: ${parentCommand.fullLabel} - Couldn't init subcommands.`);
             return;
         }
 
-        for (const Value of Object.values(parentCommand.subcmds) ) {
+        for (const Value of Object.values(subcmds) ) {
             const subCommand = new Value(this._module);
-            if (!subCommand.isSubcmd) {
-                this.logger.error(`[Module(${this._module.label})] Command: ${subCommand.fullLabel} - Couldn't load subcommand: Not a subcommand.`);
-                break;
-            }
             this.load(subCommand, parentCommand);
         }
     }
@@ -155,7 +152,6 @@ class CommandLoader extends ALoader {
             command.subCommands = new CommandRegistry(command.axon);
             this.loadSubCommands(command);
         }
-        delete command.subcmds;
        
         this.axon.commandRegistry.register(command.label, command); // add the command to the Map of commands.
     }
@@ -172,7 +168,6 @@ class CommandLoader extends ALoader {
             command.subCommands = new CommandRegistry(command.axon);
             this.loadSubCommands(command);
         }
-        delete command.subcmds;
         
         // assign parentCommand
         command.parentCommand = parent;
@@ -195,7 +190,7 @@ class CommandLoader extends ALoader {
         }
 
         /* Unregister command */
-        if (command.isSubcmd) {
+        if (command.parentCommand) {
             this.unregisterSubCommand(command.parentCommand, command);
         } else {
             this.axon.commandRegistry.unregister(command.label, command);

--- a/src/Core/Loaders/CommandLoader.js
+++ b/src/Core/Loaders/CommandLoader.js
@@ -80,10 +80,10 @@ class CommandLoader extends ALoader {
     }
 
     /**
-     * Load all commands in the module.
+     * Load all non instantiated commands in the module.
      * Instantiate all commands.
      *
-     * @param {Object.<string, Command>} commands
+     * @param {Object.<string, Command>} commands - Non instantiated Commands
      * @returns {Boolean}
      * @memberof CommandLoader
      */
@@ -108,7 +108,7 @@ class CommandLoader extends ALoader {
      * Init and construct/instance all subcommands of the given parent command
      *
      * @param {Command} parentCommand - The command Object
-     * @param {Array<new (...args[]: any) => Command>} subCommands - Array of Command class to load
+     * @param {Array<new (...args[]: any) => Command>} subCommands - Array of Command class to load (non instantiated)
      * @returns {Boolean} - Wether it loaded the subcommands or not
      * @memberof Command
      */

--- a/src/Core/Loaders/CommandLoader.js
+++ b/src/Core/Loaders/CommandLoader.js
@@ -108,7 +108,7 @@ class CommandLoader extends ALoader {
      * Init and construct/instance all subcommands of the given parent command
      *
      * @param {Command} parentCommand - The command Object
-     * @param {Array<Command>} subCommands - Array of Command class to load
+     * @param {Array<new (...args[]: any) => Command>} subCommands - Array of Command class to load
      * @returns {Boolean} - Wether it loaded the subcommands or not
      * @memberof Command
      */

--- a/src/Core/Loaders/CommandLoader.js
+++ b/src/Core/Loaders/CommandLoader.js
@@ -109,7 +109,7 @@ class CommandLoader extends ALoader {
      *
      * @param {Command} parentCommand - The command Object
      * @param {Array<new (...args[]: any) => Command>} subCommands - Array of Command class to load (non instantiated)
-     * @returns {Boolean} - Wether it loaded the subcommands or not
+     * @returns {Boolean} - Whether it loaded the subcommands or not
      * @memberof Command
      */
     loadSubCommands(parentCommand, subCommands) {


### PR DESCRIPTION
# PULL REQUEST

## **Overview**

This PR rework the way Subcommands are initialised.
Before, we had to use `subcmd` property which would be later deleted. As mutating object at runtime has drawback for performance, we are changing the approach.
Using the same approache as for `Module`, we now override an init method in Command that returns an Array of Command Class.

This also allow us to change the way Subcommands are initialised via CommandLoaders to make it cleaner, and more logical.

For a minimal backward compatibility, we make init default to use `Command.subcmd`. This is planned to be removed later on.

## **Status**

- [X] Typings have been updated or don't need to be.
- [X] This PR have been tested and is ready to be merged.

## **Semantic versioning classification**

- [X] This PR introduces *BREAKING* changes.
- [ ] This PR adds new features, improve the code and implies minimal changes.
- [ ] This PR fixes a bug and references the relevant issue or documentation.
- [ ] This PR improve performance or code refactor without API changes.
- [ ] This PR **only** includes non-code changes (documentation, CI, tools...).
