### PR TITLE
Fix UserLock - user being locked forever.

### DIFF
--- a/src/Core/Command/Command.js
+++ b/src/Core/Command/Command.js
@@ -201,16 +201,6 @@ class Command extends Base {
         const userID = this.library.message.getAuthorID(msg);
         const channel = this.library.message.getChannel(msg);
 
-        /* Test for userLock */
-        const userIsLocked = this._userLock.isLocked(userID);
-        if (userIsLocked) {
-            return new CommandContext(this, msg, {
-                executed: false,
-                executionType: env.executionType,
-                executionState: COMMAND_EXECUTION_STATE.USERLOCK,
-            } ).resolveAsync();
-        }
-
         if (!guildConfig) { // DM EXECUTION
             if (this.options.isGuildOnly() ) { // guild only
                 return new CommandContext(this, msg, {
@@ -286,6 +276,16 @@ class Command extends Base {
                 ).then( () => ctx.resolveSync() );
             }
             return ctx.resolveAsync();
+        }
+        
+        /* Test for userLock */
+        const userIsLocked = this._userLock.isLocked(userID);
+        if (userIsLocked) {
+            return new CommandContext(this, msg, {
+                executed: false,
+                executionType: env.executionType,
+                executionState: COMMAND_EXECUTION_STATE.USERLOCK,
+            } ).resolveAsync();
         }
 
         /** Doesn't delete the input if any other condition didn't pass through. */

--- a/src/Core/Command/Command.js
+++ b/src/Core/Command/Command.js
@@ -328,7 +328,6 @@ class Command extends Base {
             .catch(err => {
                 !env.isAdmin && this._cooldown.shouldSetCooldown() && this._cooldown.setCooldown(this.library.message.getAuthorID(msg) );
                 this._userLock.unLock(this.library.message.getAuthorID(msg) );
-
                 context.addResponseData(new CommandResponse( { success: false, triggerCooldown: true, error: err } ) );
                 throw new AxonCommandError(context, err);
             } );

--- a/src/Core/Command/Command.js
+++ b/src/Core/Command/Command.js
@@ -204,7 +204,7 @@ class Command extends Base {
         /* Test for userLock */
         const userIsLocked = this._userLock.isLocked(userID);
 
-        /** If user is lock then retunr */
+        /** If user is locked, return */
         if (userIsLocked) {
             return new CommandContext(this, msg, {
                 executed: false,

--- a/src/Core/Command/Command.js
+++ b/src/Core/Command/Command.js
@@ -201,11 +201,11 @@ class Command extends Base {
         const userID = this.library.message.getAuthorID(msg);
         const channel = this.library.message.getChannel(msg);
 
-        /* Test for userLock */
-        const userIsLocked = this._userLock.isLocked(userID);
-
-        /** If user is locked, return */
-        if (userIsLocked) {
+        /**
+         * Test for userLock 
+         * If user is locked, return 
+         * */
+        if (this._userLock.isLocked(userID) ) {
             return new CommandContext(this, msg, {
                 executed: false,
                 executionType: env.executionType,
@@ -289,10 +289,7 @@ class Command extends Base {
             }
             return ctx.resolveAsync();
         }
-        
-        /** Locking the user to one command instance. */
-        this._userLock.setLock(userID);
-        
+              
         /** Doesn't delete the input if any other condition didn't pass through. */
         if (this.options.shouldDeleteCommand() ) {
             this.library.message.delete(msg).catch(this.logger.warn);
@@ -315,6 +312,9 @@ class Command extends Base {
      * @memberof Command
      */
     _execute(env) {
+        /** Locking the user to one command instance. */
+        this._userLock.setLock(env.msg.author.id);
+
         const { msg } = env;
         const context = new CommandContext(this, msg, {
             executed: true,

--- a/src/Core/Command/Command.js
+++ b/src/Core/Command/Command.js
@@ -201,10 +201,7 @@ class Command extends Base {
         const userID = this.library.message.getAuthorID(msg);
         const channel = this.library.message.getChannel(msg);
 
-        /**
-         * Test for userLock 
-         * If user is locked, return 
-         * */
+        /** Test for userLock. If user is locked, return */
         if (this._userLock.isLocked(userID) ) {
             return new CommandContext(this, msg, {
                 executed: false,

--- a/src/Core/Command/Command.js
+++ b/src/Core/Command/Command.js
@@ -291,9 +291,9 @@ class Command extends Base {
         }
         
         /** Locking the user to one command instance. */
-         this._userLock.setLock(userID)
+        this._userLock.setLock(userID);
         
-         /** Doesn't delete the input if any other condition didn't pass through. */
+        /** Doesn't delete the input if any other condition didn't pass through. */
         if (this.options.shouldDeleteCommand() ) {
             this.library.message.delete(msg).catch(this.logger.warn);
         }

--- a/src/Core/Command/Command.js
+++ b/src/Core/Command/Command.js
@@ -286,7 +286,6 @@ class Command extends Base {
             }
             return ctx.resolveAsync();
         }
-              
         /** Doesn't delete the input if any other condition didn't pass through. */
         if (this.options.shouldDeleteCommand() ) {
             this.library.message.delete(msg).catch(this.logger.warn);

--- a/src/Core/Command/Command.js
+++ b/src/Core/Command/Command.js
@@ -309,7 +309,7 @@ class Command extends Base {
      */
     _execute(env) {
         /** Locking the user to one command instance. */
-        this._userLock.setLock(env.msg.author.id);
+        this._userLock.setLock(this.library.message.getAuthorID(env.msg) );
 
         const { msg } = env;
         const context = new CommandContext(this, msg, {

--- a/src/Core/Command/CommandOptions.js
+++ b/src/Core/Command/CommandOptions.js
@@ -44,7 +44,7 @@ class CommandOptions {
      * @param {Boolean} override.guildOnly - Whether to allow executing this command outside of guilds
      * @param {Boolean} override.hidden - Whether to hide this command from help command (general / subcommands)
      * @param {Number} override.cooldown - Cooldown between each usage of this command for a specific user (in ms)
-     * @prop {Boolean} override.userLock - One user can only run one instance of the command at a time across all guilds
+     * @param {Boolean} override.userLock - One user can only run one instance of the command at a time across all guilds
      * @param {Boolean} [useModuleDefault=false] - Whether to use or not the module's base options before applying override permissions
      * @memberof CommandOptions
      */

--- a/src/Core/Command/CommandOptions.js
+++ b/src/Core/Command/CommandOptions.js
@@ -26,7 +26,7 @@ import AxonError from '../../Errors/AxonError';
  * @prop {Boolean} [guildOnly=true] - Whether to allow executing this command outside of guilds
  * @prop {Boolean} [hidden=false] - Whether to hide this command from help command (general / subcommands)
  * @prop {Number} [cooldown=3000] - Cooldown between each usage of this command for a specific user (in ms)
- * @prop {Boolean} [userLock=false] - One user can only run one instance of the command at a time.
+ * @prop {Boolean} [userLock=false] - One user can only run one instance of the command at a time across all guilds.
  */
 class CommandOptions {
     /**
@@ -44,7 +44,7 @@ class CommandOptions {
      * @param {Boolean} override.guildOnly - Whether to allow executing this command outside of guilds
      * @param {Boolean} override.hidden - Whether to hide this command from help command (general / subcommands)
      * @param {Number} override.cooldown - Cooldown between each usage of this command for a specific user (in ms)
-     * @prop {Boolean} override.userLock - One user can only run one instance of the command at a time.
+     * @prop {Boolean} override.userLock - One user can only run one instance of the command at a time across all guilds
      * @param {Boolean} [useModuleDefault=false] - Whether to use or not the module's base options before applying override permissions
      * @memberof CommandOptions
      */

--- a/src/Core/Command/CommandOptions.js
+++ b/src/Core/Command/CommandOptions.js
@@ -146,6 +146,16 @@ class CommandOptions {
     }
 
     /**
+     * Whether the userLock option is enabled or not.
+     *
+     * @returns {Boolean}
+     * @memberof CommandOptions
+     */
+    shouldLock() {
+        return this.userLock;
+    }
+
+    /**
      * Whether the command is hidden or not
      *
      * @returns {Boolean}

--- a/src/Core/Command/CommandOptions.js
+++ b/src/Core/Command/CommandOptions.js
@@ -151,7 +151,7 @@ class CommandOptions {
      * @returns {Boolean}
      * @memberof CommandOptions
      */
-    shouldLock() {
+    shouldUserLock() {
         return this.userLock;
     }
 

--- a/src/Core/Command/CommandUserLock.js
+++ b/src/Core/Command/CommandUserLock.js
@@ -54,7 +54,7 @@ class CommandUserLock {
      * @returns {Boolean} Whether the user is unlocked or not.
      * @memberof CommandUserLock
      */
-    unLock(userID) {      
+    unLock(userID) {
         if (this._usersLocked.has(userID) ) {
             this._usersLocked.delete(userID); // User is now unlocked.
             return true;

--- a/src/Core/Command/CommandUserLock.js
+++ b/src/Core/Command/CommandUserLock.js
@@ -34,7 +34,7 @@ class CommandUserLock {
      * @memberof CommandUserLock
      */
     get userLock() {
-        return this._command.options.userLock;
+        return this._command.options.shouldLock();
     }
 
     /**

--- a/src/Core/Command/CommandUserLock.js
+++ b/src/Core/Command/CommandUserLock.js
@@ -15,7 +15,6 @@
 class CommandUserLock {
     /**
      * Creates an instance of CommandUserLock.
-     *
      * @param {Command} command
      * @memberof CommandUserLock
      */
@@ -30,7 +29,6 @@ class CommandUserLock {
 
     /**
      * Returns the status of the userlock option.
-     *
      * @readonly
      * @type {Boolean} Options of userLock.
      * @memberof CommandUserLock
@@ -41,10 +39,8 @@ class CommandUserLock {
 
     /**
      * Checks if the user is locked.
-     * Lock the user if not locked.
      * @param {String} userID - The userID
      * @returns {Boolean} Whether the user is locked or not.
-     *
      * @memberof CommandUserLock
      */
     isLocked(userID) {
@@ -52,8 +48,7 @@ class CommandUserLock {
 
         // Not locked yet
         if (!lock) {
-            this._setLock(userID); // lock the user.
-            return false;
+             return false;
         }
 
         return true;
@@ -61,7 +56,6 @@ class CommandUserLock {
 
     /**
      * Unlock a user.
-     *
      * @param {String} userID - The userID
      * @returns {Boolean} Whether the user is unlocked or not.
      * @memberof CommandUserLock
@@ -83,7 +77,7 @@ class CommandUserLock {
      * @param {String} userID
      * @memberof CommandUserLock
      */
-    _setLock(userID) {
+    setLock(userID) {
         this._usersLocked.add(userID); // User is now locked.
     }
 }

--- a/src/Core/Command/CommandUserLock.js
+++ b/src/Core/Command/CommandUserLock.js
@@ -48,7 +48,7 @@ class CommandUserLock {
 
         // Not locked yet
         if (!lock) {
-             return false;
+            return false;
         }
 
         return true;

--- a/src/Core/Command/CommandUserLock.js
+++ b/src/Core/Command/CommandUserLock.js
@@ -41,11 +41,11 @@ class CommandUserLock {
      * Checks if the user is locked.
      * @param {String} userID - The userID
      * @returns {Boolean} Whether the user is locked or not.
-     * 
+     *
      * @memberof CommandUserLock
      */
     isLocked(userID) {
-        return this._usersLocked.has(userID)
+        return this._usersLocked.has(userID);
     }
 
     /**
@@ -54,10 +54,8 @@ class CommandUserLock {
      * @returns {Boolean} Whether the user is unlocked or not.
      * @memberof CommandUserLock
      */
-    unLock(userID) {
-        const lock = this._usersLocked.has(userID);
-        
-        if (this._usersLocked.has(userID)) {
+    unLock(userID) {      
+        if (this._usersLocked.has(userID) ) {
             this._usersLocked.delete(userID); // User is now unlocked.
             return true;
         }

--- a/src/Core/Command/CommandUserLock.js
+++ b/src/Core/Command/CommandUserLock.js
@@ -41,17 +41,11 @@ class CommandUserLock {
      * Checks if the user is locked.
      * @param {String} userID - The userID
      * @returns {Boolean} Whether the user is locked or not.
+     * 
      * @memberof CommandUserLock
      */
     isLocked(userID) {
-        const lock = this._usersLocked.has(userID);
-
-        // Not locked yet
-        if (!lock) {
-            return false;
-        }
-
-        return true;
+        return this._usersLocked.has(userID)
     }
 
     /**
@@ -63,7 +57,7 @@ class CommandUserLock {
     unLock(userID) {
         const lock = this._usersLocked.has(userID);
         
-        if (lock) {
+        if (this._usersLocked.has(userID)) {
             this._usersLocked.delete(userID); // User is now unlocked.
             return true;
         }

--- a/src/Core/Command/CommandUserLock.js
+++ b/src/Core/Command/CommandUserLock.js
@@ -33,8 +33,8 @@ class CommandUserLock {
      * @type {Boolean} Options of userLock.
      * @memberof CommandUserLock
      */
-    get userLock() {
-        return this._command.options.shouldLock();
+    get shouldLock() {
+        return this._command.options.shouldUserLock();
     }
 
     /**

--- a/src/Langs/TranslationManager.js
+++ b/src/Langs/TranslationManager.js
@@ -72,13 +72,7 @@ class TranslationManager {
     getMessage(message, lang) {
         const paths = message.split('.');
         let toReturn = this.getMessages(lang) || this.getMessages(this.lang);
-
-        for (const elem of paths) {
-            if (!toReturn[elem] ) {
-                return paths.reduce( (acc, e) => (acc = acc[e] ), this.getMessages(this.lang) );
-            }
-            toReturn = toReturn[elem];
-        }
+        paths.forEach( (p) => (toReturn = toReturn[p] ) );
         return toReturn;
     }
 }

--- a/src/Langs/TranslationManager.js
+++ b/src/Langs/TranslationManager.js
@@ -72,7 +72,13 @@ class TranslationManager {
     getMessage(message, lang) {
         const paths = message.split('.');
         let toReturn = this.getMessages(lang) || this.getMessages(this.lang);
-        paths.forEach( (p) => (toReturn = toReturn[p] ) );
+
+        for (const elem of paths) {
+            if (!toReturn[elem] ) {
+                return paths.reduce( (acc, e) => (acc = acc[e] ), this.getMessages(this.lang) );
+            }
+            toReturn = toReturn[elem];
+        }
         return toReturn;
     }
 }

--- a/types/Core/Command/Command.ts
+++ b/types/Core/Command/Command.ts
@@ -1,5 +1,5 @@
 import {
-    Base, CommandData, Module, CommandCooldown, CommandInfo, CommandOptions, CommandPermissions, CommandRegistry,
+    Base, CommandData, Module, CommandUserLock, CommandCooldown, CommandInfo, CommandOptions, CommandPermissions, CommandRegistry,
     AxonTemplate, LibraryInterface, CommandContext, CommandResponse, LibTextableChannel, LibMember, CommandEnvironment,
 } from '../../';
 
@@ -16,6 +16,9 @@ export declare class Command extends Base implements CommandData {
      * Module object
      */
     private _module: Module;
+
+    private _userLock: CommandUserLock;
+
     /**
      * Cooldown Object for the command (manage all command cooldowns)
      */

--- a/types/Core/Command/CommandOptions.ts
+++ b/types/Core/Command/CommandOptions.ts
@@ -55,7 +55,7 @@ export declare class CommandOptions implements ACommandOptions {
      *
      * @memberof CommandOptions
      */
-    shouldLock(): boolean;
+    shouldUserLock(): boolean;
     /**
      * Whether the command is hidden or not
      *

--- a/types/Core/Command/CommandOptions.ts
+++ b/types/Core/Command/CommandOptions.ts
@@ -51,6 +51,12 @@ export declare class CommandOptions implements ACommandOptions {
      */
     public isGuildOnly(): boolean;
     /**
+     * Whether the userLock option is enabled or not.
+     *
+     * @memberof CommandOptions
+     */
+    shouldLock(): boolean;
+    /**
      * Whether the command is hidden or not
      *
      * @memberof CommandOptions

--- a/types/Core/Command/CommandUserLock.ts
+++ b/types/Core/Command/CommandUserLock.ts
@@ -35,10 +35,8 @@ export declare class CommandUserLock {
     // METHODS
     /**
      * Checks if the user is locked.
-     * Lock the user if not locked.
      * @param {String} userID - The userID
      * @returns {Boolean} Whether the user is locked or not.
-     *
      * @memberof CommandUserLock
      */
     public isLocked(userID: string): boolean;
@@ -56,5 +54,5 @@ export declare class CommandUserLock {
      * @param {String} userID
      * @memberof CommandUserLock
      */
-    private _setLock(userID: string): void;
+    public setLock(userID: string): void;
 }

--- a/types/Core/Command/CommandUserLock.ts
+++ b/types/Core/Command/CommandUserLock.ts
@@ -12,6 +12,7 @@ export declare class CommandUserLock {
      * The base command
      */
     private _command: Command;
+    
     /**
      * All user IDs currently locked
      */

--- a/types/Core/Command/CommandUserLock.ts
+++ b/types/Core/Command/CommandUserLock.ts
@@ -31,7 +31,7 @@ export declare class CommandUserLock {
      * @readonly
      * @memberof CommandUserLock
      */
-    readonly userLock: boolean;
+    readonly shouldLock: boolean;
 
     // METHODS
     /**

--- a/types/index.ts
+++ b/types/index.ts
@@ -43,6 +43,7 @@ export {
 
 export { Command } from './Core/Command/Command';
 export { CommandContext } from './Core/Command/CommandContext';
+export { CommandUserLock } from './Core/Command/CommandUserLock';
 export { CommandCooldown } from './Core/Command/CommandCooldown';
 export { CommandEnvironment } from './Core/Command/CommandEnvironment';
 export { CommandOptions } from './Core/Command/CommandOptions';


### PR DESCRIPTION
# PULL REQUEST

## **Overview**

The verification of a "Locked" user always takes place first, but a user will be set as "Locked" just before the execution of the command to prevent a user from getting blocked forever.

## **Status**

- [X] Typings have been updated or don't need to be.
- [x] This PR have been tested and is ready to be merged.

## **Semantic versioning classification**

- [X] PATCH: This PR fixes a bug, if needed it also references the relevant issue or documentation.

